### PR TITLE
Help command consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 .vscode/
 Include/
 Lib/

--- a/cmds/it140.py
+++ b/cmds/it140.py
@@ -95,7 +95,7 @@ def execute(command, user):
         topic = cmd[1].lower()
         try:
             if topic == "help":
-                response = "Here is a list of valid IT-140 topics:\n\n" + "\n".join("`{}`".format(x) for x in data.keys() if x != "it140")
+                response = "Here is a list of valid IT-140 topics:\n\n" + "\n".join("- `{}`".format(x) for x in data.keys() if x != "it140")
             else:
                 attachment = build_attachment(topic)
         except KeyError:


### PR DESCRIPTION
I noticed an inconsistency with the formatting of the `help` output for the main bot and the `it140` command.  The primary `help` command gives the following:

![main help](https://user-images.githubusercontent.com/29785667/47607416-958add00-d9d4-11e8-97a8-ff7c26cacd4d.JPG)

This is the current output for `it140 help`:

![it 140 help - prev](https://user-images.githubusercontent.com/29785667/47607423-a76c8000-d9d4-11e8-8c7c-1a2aeb6ec941.JPG)

This pull request adds a dash to the output, resulting in:

![it 140 help - now](https://user-images.githubusercontent.com/29785667/47607431-b4896f00-d9d4-11e8-8f24-3b99261bcd0e.JPG)
