### PR TITLE
Packtbook Update

### DIFF
--- a/cmds/packtbook.py
+++ b/cmds/packtbook.py
@@ -5,6 +5,7 @@ import time
 from bs4 import BeautifulSoup
 from dateutil.relativedelta import relativedelta
 from urllib.request import urlopen
+from urllib.error import HTTPError
 
 command = 'packtbook'
 public = True
@@ -28,9 +29,9 @@ def execute(command, user):
 
         # Grab the book title
         book_box = soup.find('div', attrs={'class':'dotd-title'})
-        book_title = book_box.text.strip()
+        book_title = book_box.text.strip() if book_box else None
 
-        if book_title != "":
+        if book_title:
             # Grab the book image
             book_img = soup.find('img', attrs={'class':'bookimage'})
             book_img_src = book_img['src'].strip().replace(' ', '%20')
@@ -73,6 +74,10 @@ def execute(command, user):
         else:
             response = "Apologies, but there appears to not be a free book today.  Maybe tomorrow! :crossed_fingers:"
 
+    except HTTPError as err:
+        print(err)
+
+        response = "It appears that the free book page doesn't exist anymore.  Are they still giving away books?"
     except Exception as err:
         print(err)
 

--- a/cmds/packtbook.py
+++ b/cmds/packtbook.py
@@ -30,45 +30,48 @@ def execute(command, user):
         book_box = soup.find('div', attrs={'class':'dotd-title'})
         book_title = book_box.text.strip()
 
-        # Grab the book image
-        book_img = soup.find('img', attrs={'class':'bookimage'})
-        book_img_src = book_img['src'].strip().replace(' ', '%20')
-        # format book image
-        if book_img_src.lower().startswith("//"):
-            book_img_src = "https" + book_img_src
-        elif not book_img_src.lower().startswith("https://"):
-            book_img_src = "https://" + book_img_src
+        if book_title != "":
+            # Grab the book image
+            book_img = soup.find('img', attrs={'class':'bookimage'})
+            book_img_src = book_img['src'].strip().replace(' ', '%20')
+            # format book image
+            if book_img_src.lower().startswith("//"):
+                book_img_src = "https" + book_img_src
+            elif not book_img_src.lower().startswith("https://"):
+                book_img_src = "https://" + book_img_src
 
-        # Grab the timestamps
-        book_expires = soup.find('span', attrs={'class':'packt-js-countdown'})
-        expires_time = datetime.datetime.fromtimestamp(int(book_expires['data-countdown-to']))
-        cur_time = datetime.datetime.fromtimestamp(int(time.time()))        
-        
-        # Figure out time output (handles plurals)
-        attrs = ['hours', 'minutes', 'seconds']
-        human_readable = lambda delta: ['{} {}'.format(
-            getattr(delta, attr),
-            getattr(delta, attr) > 1 and attr or attr[:-1])
-            for attr in attrs if getattr(delta, attr)]
-        
-        time_diff = relativedelta(expires_time, cur_time)
-        times = human_readable(time_diff)
+            # Grab the timestamps
+            book_expires = soup.find('span', attrs={'class':'packt-js-countdown'})
+            expires_time = datetime.datetime.fromtimestamp(int(book_expires['data-countdown-to']))
+            cur_time = datetime.datetime.fromtimestamp(int(time.time()))
 
-        time_string = ", ".join(times)
-        #time_string = {}, {}, and {}".format(*times)
+            # Figure out time output (handles plurals)
+            attrs = ['hours', 'minutes', 'seconds']
+            human_readable = lambda delta: ['{} {}'.format(
+                getattr(delta, attr),
+                getattr(delta, attr) > 1 and attr or attr[:-1])
+                for attr in attrs if getattr(delta, attr)]
 
-        output = {"pretext":"The Packt Free Book of the Day is:",
-                "title":book_title,
-                "title_link":url,
-                "footer":"There's still {} to get this book!".format(time_string),                
-                "color":"#ffca5b"}
-        
-        if mini:
-            output['thumb_url'] = "{}".format(book_img_src)
+            time_diff = relativedelta(expires_time, cur_time)
+            times = human_readable(time_diff)
+
+            time_string = ", ".join(times)
+            #time_string = {}, {}, and {}".format(*times)
+
+            output = {"pretext":"The Packt Free Book of the Day is:",
+                    "title":book_title,
+                    "title_link":url,
+                    "footer":"There's still {} to get this book!".format(time_string),
+                    "color":"#ffca5b"}
+
+            if mini:
+                output['thumb_url'] = "{}".format(book_img_src)
+            else:
+                output['image_url'] = "{}".format(book_img_src)
+
+            attachment = json.dumps([output])
         else:
-            output['image_url'] = "{}".format(book_img_src)
-
-        attachment = json.dumps([output])
+            response = "Apologies, but there appears to not be a free book today.  Maybe tomorrow! :crossed_fingers:"
 
     except Exception as err:
         print(err)


### PR DESCRIPTION
It got depressing looking at the empty attachment every day, so I went ahead and did a workaround.  As it turns out, they leave the free book `<div>` in there (for whatever reason), but the fields are empty.  Thus, if the parsing results in an empty book title I misdirect the output to something that informs everyone that there is no sale.

Probably a better way to do it, but it works.  This solution accounts for both `packtbook` and `packtbook mini`.

![new packtbook](https://user-images.githubusercontent.com/29785667/50404809-a6a06200-0769-11e9-8092-290cc8476fed.JPG)
