### PR TITLE
Catalog Update

### DIFF
--- a/cmds/snhu_catalog.py
+++ b/cmds/snhu_catalog.py
@@ -40,7 +40,7 @@ def execute(command, user):
     if disabled:
         response = "I'm sorry. This command has been disabled because I'm currently running without a database connection."
     else:
-        COURSE_FORMAT = r"[a-zA-Z]{2,3}[- ]?[0-9]{3}" # CS499, CS 499, CS-499, ACC-499, etc.
+        COURSE_FORMAT = r"[a-zA-Z]{2,4}[- ]?[0-9]{3}" # CS499, CS 499, CS-499, ACC-499, etc.
         course_matches = re.findall(COURSE_FORMAT, command)
         requests = command.split()        
 


### PR DESCRIPTION
A few small updates to the command.  First, the regular expression was adjusted to account for spaces in course titles.  Extending from this, `re.findall()` is now used to find the requested courses in `command` instead of enumerating a list from a split.

Max courses remains at 3, but can now be adjusted to any number.  The bad course functionality remains intact and this update should have no effect on the subjects search.  I think.

![new catalog](https://user-images.githubusercontent.com/29785667/50404914-8de47c00-076a-11e9-99fe-658b62fb50c1.JPG)
